### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/5](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/5)

To fix the issue, we should avoid using the `$where` operator with user-provided input. Instead, we can use a parameterized query to safely query the database. Specifically, we can replace the `$where` query with a direct query using the `orderId` field. This approach eliminates the need to execute JavaScript code and ensures that user input is treated as data, not code.

Changes to make:
1. Replace the `$where` query with a direct query using the `orderId` field.
2. Ensure that the `id` parameter is properly sanitized and validated before use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
