### PR TITLE
Potential fix for code scanning alert no. 25: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -70,7 +70,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
         res.render('dataErasureResult', {
-          ...req.body
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -85,7 +86,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       }
     } else {
       res.render('dataErasureResult', {
-        ...req.body
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/25](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/25)

To fix the issue, we need to avoid directly spreading the user-controlled `req.body` object into the template rendering context. Instead, we should explicitly construct a new object with only the specific properties required by the template. This ensures that no unintended or malicious properties can be injected into the template engine.

1. Identify the specific properties from `req.body` that are required by the `dataErasureResult` template.
2. Construct a new object containing only these properties.
3. Replace the direct use of `{ ...req.body }` with the explicitly constructed object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
