### PR TITLE
Potential fix for code scanning alert no. 94: Incomplete string escaping or encoding

### DIFF
--- a/data/static/codefixes/unionSqlInjectionChallenge_1.ts
+++ b/data/static/codefixes/unionSqlInjectionChallenge_1.ts
@@ -2,8 +2,9 @@ export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
-    criteria.replace(/"|'|;|and|or/i, "")
-    models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`)
+    const sqlstring = require('sqlstring');
+    criteria = sqlstring.escape(criteria);
+    models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE ${criteria} OR description LIKE ${criteria}) AND deletedAt IS NULL) ORDER BY name`)
       .then(([products]: any) => {
         const dataString = JSON.stringify(products)
         for (let i = 0; i < products.length; i++) {

--- a/package.json
+++ b/package.json
@@ -185,7 +185,8 @@
     "web3": "^4.13.0",
     "winston": "^3.16.0",
     "yaml-schema-validator": "^1.2.3",
-    "z85": "^0.0.2"
+    "z85": "^0.0.2",
+    "sqlstring": "^2.3.3"
   },
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^2.0.0||^3.0.0",


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/94](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/94)

To fix the problem, we need to ensure that all occurrences of the specified patterns in the `criteria` string are sanitized. The best approach is to use a well-tested sanitization library, such as `sqlstring`, to escape the input properly. Alternatively, we can rewrite the regular expression to include the `g` flag for global replacement. However, using prepared statements is the safest and most recommended solution, as it eliminates the need for manual sanitization altogether.

In this case, we will use the `sqlstring` library to escape the `criteria` string before embedding it into the SQL query. This ensures that all meta-characters are properly escaped, preventing SQL injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
