### PR TITLE
Potential fix for code scanning alert no. 68: Use of password hash with insufficient computational effort

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -40,7 +40,9 @@ interface IAuthenticatedUsers {
   updateFrom: (req: Request, user: ResponseWithUser) => any
 }
 
-export const hash = (data: string) => crypto.createHash('md5').update(data).digest('hex')
+import bcrypt from 'bcrypt';
+
+export const hash = (data: string) => bcrypt.hashSync(data, 10);
 export const hmac = (data: string) => crypto.createHmac('sha256', 'pa4qacea4VK9t9nGv7yZtwmj').update(data).digest('hex')
 
 export const cutOffPoisonNullByte = (str: string) => {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,8 @@
     "winston": "^3.16.0",
     "yaml-schema-validator": "^1.2.3",
     "z85": "^0.0.2",
-    "sqlstring": "^2.3.3"
+    "sqlstring": "^2.3.3",
+    "bcrypt": "^6.0.0"
   },
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^2.0.0||^3.0.0",

--- a/routes/2fa.ts
+++ b/routes/2fa.ts
@@ -11,7 +11,8 @@ import * as challengeUtils from '../lib/challengeUtils'
 import * as utils from '../lib/utils'
 import { challenges } from '../data/datacache'
 import * as otplib from 'otplib'
-import * as security from '../lib/insecurity'
+import * as security from '../lib/insecurity';
+import bcrypt from 'bcrypt';
 
 otplib.authenticator.options = {
   // Accepts tokens as valid even when they are 30sec to old or to new
@@ -110,7 +111,7 @@ export async function setup (req: Request, res: Response) {
 
     const { password, setupToken, initialToken } = req.body
 
-    if (user.password !== security.hash(password)) {
+    if (!bcrypt.compareSync(password, user.password)) {
       throw new Error('Password doesnt match stored password')
     }
 
@@ -155,7 +156,7 @@ export async function disable (req: Request, res: Response) {
 
     const { password } = req.body
 
-    if (user.password !== security.hash(password)) {
+    if (!bcrypt.compareSync(password, user.password)) {
       throw new Error('Password doesnt match stored password')
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/68](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/68)

To fix the issue, replace the insecure `md5` hashing algorithm with a secure password hashing scheme such as `bcrypt`. This ensures that passwords are hashed with sufficient computational effort, making it significantly harder for attackers to brute-force or reverse the hashes.

**Steps to implement the fix:**
1. Replace the `hash` function in `lib/insecurity.ts` to use `bcrypt.hashSync` for hashing passwords.
2. Update the `routes/2fa.ts` file to ensure that password comparison uses `bcrypt.compareSync` instead of direct string comparison.
3. Add the necessary import for `bcrypt` in `lib/insecurity.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
