### PR TITLE
Potential fix for code scanning alert no. 65: Client-side cross-site scripting

### DIFF
--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -156,7 +156,7 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
         this.io.socket().emit('verifyLocalXssChallenge', queryParam)
       }) // vuln-code-snippet hide-end
       this.dataSource.filter = queryParam.toLowerCase()
-      this.searchValue = this.sanitizer.bypassSecurityTrustHtml(queryParam) // vuln-code-snippet vuln-line localXssChallenge xssBonusChallenge
+      this.searchValue = this.sanitizer.sanitize(1, queryParam) // Sanitize the queryParam to prevent XSS
       this.gridDataSource.subscribe((result: any) => {
         if (result.length === 0) {
           this.emptyState = true


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/65](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/65)

To fix the issue, we need to ensure that the user-provided input (`queryParam`) is properly sanitized before it is rendered in the DOM. Instead of using `bypassSecurityTrustHtml()`, which disables Angular's built-in security mechanisms, we should use Angular's built-in DOM sanitization methods or escape the input to prevent XSS.

The best approach is to remove the use of `bypassSecurityTrustHtml()` and directly bind the sanitized or escaped value to the DOM. Angular's `DomSanitizer` provides a `sanitize()` method that can be used to sanitize the input in a safe manner. Alternatively, we can escape the input using a utility function to ensure that any HTML tags or special characters are rendered as plain text.

Changes will be made to the `filterTable()` method to sanitize the `queryParam` value before assigning it to `this.searchValue`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
