### PR TITLE
Potential fix for code scanning alert no. 76: Database query built from user-controlled sources

### DIFF
--- a/routes/updateProductReviews.ts
+++ b/routes/updateProductReviews.ts
@@ -14,8 +14,12 @@ import * as db from '../data/mongodb'
 export function updateProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = security.authenticatedUsers.from(req) // vuln-code-snippet vuln-line forgedReviewChallenge
+    if (typeof req.body.id !== 'string') {
+      res.status(400).json({ error: 'Invalid ID format' });
+      return;
+    }
     db.reviewsCollection.update( // vuln-code-snippet neutral-line forgedReviewChallenge
-      { _id: req.body.id }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
+      { _id: { $eq: req.body.id } }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
       { $set: { message: req.body.message } },
       { multi: true } // vuln-code-snippet vuln-line noSqlReviewsChallenge
     ).then(


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/76](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/76)

To fix the issue, we need to ensure that the user-provided `req.body.id` is interpreted as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator or by validating the input to ensure it is a literal value (e.g., a string or a valid ObjectId). 

The best approach is to use the `$eq` operator, as it directly addresses the vulnerability by treating the input as a literal value. Additionally, we can add input validation to ensure `req.body.id` is of the expected type (e.g., a string or ObjectId).

Changes required:
1. Modify the query to use the `$eq` operator for `_id`.
2. Optionally, add validation to check that `req.body.id` is a string or a valid ObjectId.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
