### PR TITLE
Potential fix for code scanning alert no. 29: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -17,7 +17,17 @@ export function profileImageUrlUpload () {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
-      if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
+      const trustedDomains = ['example.com', 'images.com']; // Allow-list of trusted domains
+      try {
+        const parsedUrl = new URL(url);
+        if (!trustedDomains.includes(parsedUrl.hostname)) {
+          throw new Error('URL hostname is not trusted');
+        }
+        if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
+      } catch (error) {
+        next(new Error('Invalid or unsafe URL provided'));
+        return;
+      }
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
         try {


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/29](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/29)

To fix the SSRF vulnerability, the user-provided `imageUrl` must be validated before being used in the `fetch(url)` call. Specifically:
1. Implement an allow-list of trusted hostnames or domains to ensure that the outgoing request is only made to known and safe endpoints.
2. Validate the URL structure to prevent path traversal or other malicious patterns.
3. Reject or sanitize any input that does not conform to the expected format.

The best approach is to extract the hostname from the user-provided URL and compare it against an allow-list of trusted domains. If the hostname is not in the allow-list, reject the request. Additionally, ensure that the URL does not contain dangerous patterns such as `../`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
