### PR TITLE
Potential fix for code scanning alert no. 67: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
     "yaml-schema-validator": "^1.2.3",
     "z85": "^0.0.2",
     "sqlstring": "^2.3.3",
-    "bcrypt": "^6.0.0"
+    "bcrypt": "^6.0.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^2.0.0||^3.0.0",

--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,7 @@ import helmet from 'helmet'
 import http from 'node:http'
 import path from 'node:path'
 import express from 'express'
+import lusca from 'lusca'
 import colors from 'colors/safe'
 import serveIndex from 'serve-index'
 import bodyParser from 'body-parser'
@@ -286,6 +287,8 @@ restoreOverwrittenFilesWithOriginals().then(() => {
 
   app.use(express.static(path.resolve('frontend/dist/frontend')))
   app.use(cookieParser('kekse'))
+  app.use(bodyParser.urlencoded({ extended: true }))
+  app.use(lusca.csrf())
   // vuln-code-snippet end directoryListingChallenge accessLogDisclosureChallenge
 
   /* Configure and enable backend-side i18n */
@@ -297,8 +300,6 @@ restoreOverwrittenFilesWithOriginals().then(() => {
     autoReload: true
   })
   app.use(i18n.init)
-
-  app.use(bodyParser.urlencoded({ extended: true }))
   /* File Upload */
   app.post('/file-upload', uploadToMemory.single('file'), ensureFileIsPassed, metrics.observeFileUploadMetricsMiddleware(), checkUploadSize, checkFileType, handleZipFileUpload, handleXmlUpload, handleYamlUpload)
   app.post('/profile/image/file', uploadToMemory.single('file'), ensureFileIsPassed, metrics.observeFileUploadMetricsMiddleware(), profileImageFileUpload())


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/67](https://github.com/Champmsecurity/juice-shopy_testing/security/code-scanning/67)

To fix the issue, CSRF protection middleware should be added to the application. The `lusca` package provides a straightforward way to implement CSRF protection. The middleware should be initialized after `cookieParser` and `bodyParser` but before any state-changing routes. This ensures that all relevant requests are protected against CSRF attacks.

Steps to implement the fix:
1. Install the `lusca` package.
2. Import the `lusca` package in the file.
3. Add the `lusca.csrf()` middleware after `cookieParser` and `bodyParser` initialization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
